### PR TITLE
Improved LitmusHttpClient

### DIFF
--- a/src/main/java/io/litmuschaos/LitmusClient.java
+++ b/src/main/java/io/litmuschaos/LitmusClient.java
@@ -30,22 +30,21 @@ public class LitmusClient implements AutoCloseable {
     // TODO - @Suyeon Jung : host, port config to LitmusAuthConfig class
     public LoginResponse authenticate(String host, String username, String password) throws IOException {
         LoginRequest request = new LoginRequest(username, password);
-        Response response = httpClient.post(host + "/login", request);
-        LoginResponse loginResponse = new GsonBuilder().create().fromJson(response.body().string(), LoginResponse.class);
-        this.token = loginResponse.getAccessToken();
-        return loginResponse;
+        LoginResponse response = httpClient.post(host + "/login", request, LoginResponse.class);
+        this.token = response.getAccessToken();
+        return response;
     }
 
     // TODO - define Response dto
-    public Response createProject(String host, String projectName) throws IOException {
+    public String createProject(String host, String projectName) throws IOException {
         Map<String, String> request = new HashMap<>();
         request.put("projectName", projectName);
-        return httpClient.post(host + "/create_project", token,  request);
+        return httpClient.post(host + "/create_project", token,  request, String.class);
     }
 
     // TODO - define Response dto
-    public Response capabilities(String host) throws IOException {
-        return httpClient.get(host + "/capabilities");
+    public String capabilities(String host) throws IOException {
+        return httpClient.get(host + "/capabilities", String.class);
     }
 
 }

--- a/src/main/java/io/litmuschaos/response/LoginResponse.java
+++ b/src/main/java/io/litmuschaos/response/LoginResponse.java
@@ -35,4 +35,15 @@ public class LoginResponse {
     public String getType() {
         return type;
     }
+
+    @Override
+    public String toString() {
+        return "LoginResponse{" +
+                "accessToken='" + accessToken + '\'' +
+                ", expiresIn='" + expiresIn + '\'' +
+                ", projectID='" + projectID + '\'' +
+                ", projectRole='" + projectRole + '\'' +
+                ", type='" + type + '\'' +
+                '}';
+    }
 }

--- a/src/test/java/AuthTest.java
+++ b/src/test/java/AuthTest.java
@@ -1,6 +1,4 @@
 import io.litmuschaos.LitmusClient;
-import io.litmuschaos.response.LoginResponse;
-import okhttp3.Response;
 
 import java.io.IOException;
 
@@ -16,17 +14,17 @@ public class AuthTest {
         LitmusClient authClient = new LitmusClient(hostUrl, username, password);
 
         System.out.println("### capabilities test");
-        Response response = authClient.capabilities(hostUrl);
-        System.out.println(response.body().string());
+        var capabilities = authClient.capabilities(hostUrl);
+        System.out.println(capabilities);
 
-        System.out.println("### craeteProject test");
-        response = authClient.createProject(
+        System.out.println("### createProject test");
+        var project = authClient.createProject(
                 hostUrl,
-                "TEST_Project_1");
-        System.out.println(response.body().string());
+                "TEST_Project_5");
+        System.out.println(project);
 
-        LoginResponse loginResponse = authClient.authenticate(hostUrl, username, password);
+        var auth = authClient.authenticate(hostUrl, username, password);
         System.out.println("### refresh token test");
-        System.out.println("access Token :: " + loginResponse.getAccessToken());
+        System.out.println("access Token :: " + auth.getAccessToken());
     }
 }


### PR DESCRIPTION
I have enhanced the LitmusHttpClient by adding support for specifying the return type of the get and post methods through generics. This change enables the response to be parsed into a desired object using Gson directly within the methods.

With this improvement, the logic for handling HTTP responses and parsing them into the required type is encapsulated within the get and post methods, streamlining the process so that only these methods need to be called.