### PR TITLE
Add Implement close() method

### DIFF
--- a/src/main/java/io/litmuschaos/LitmusClient.java
+++ b/src/main/java/io/litmuschaos/LitmusClient.java
@@ -21,10 +21,9 @@ public class LitmusClient implements AutoCloseable {
         LoginResponse credential = this.authenticate(host, username, password);
         this.token = credential.getAccessToken();
     }
-
     @Override
     public void close() throws Exception {
-        // TODO
+        this.httpClient.close();
     }
 
     // TODO - @Suyeon Jung : host, port config to LitmusAuthConfig class

--- a/src/main/java/io/litmuschaos/http/LitmusHttpClient.java
+++ b/src/main/java/io/litmuschaos/http/LitmusHttpClient.java
@@ -52,6 +52,10 @@ public class LitmusHttpClient implements AutoCloseable{
 
     @Override
     public void close() throws Exception {
-        // TODO
+        this.okHttpClient.dispatcher().executorService().shutdown();
+        this.okHttpClient.connectionPool().evictAll();
+        if (this.okHttpClient.cache() != null) {
+            this.okHttpClient.cache().close();
+        }
     }
 }


### PR DESCRIPTION
I have made an Implement close() method

- For okHttpClient:
The dispatcher()'s executorService() is shut down. All idle connections in the connectionPool() are evicted. If a cache exists, it is properly closed to release resources.

- For httpClient:
The close() method is invoked directly to handle resource cleanup.