### PR TITLE
Refactor HttpResponseHandler to consolidate methods 

### DIFF
--- a/src/main/java/io/litmuschaos/util/HttpResponseHandler.java
+++ b/src/main/java/io/litmuschaos/util/HttpResponseHandler.java
@@ -30,16 +30,6 @@ public class HttpResponseHandler {
     }
 
     private <T> T transform(String responseBody, Type responseType) {
-        JsonElement jsonElement = JsonParser.parseString(responseBody);
-
-        if (jsonElement.isJsonObject()) {
-            JsonObject jsonObject = jsonElement.getAsJsonObject();
-            if (jsonObject.has("data")) {
-                JsonElement dataElement = jsonObject.get("data");
-                return gson.fromJson(dataElement.toString(), responseType);
-            }
-        }
-
         return gson.fromJson(responseBody, responseType);
     }
 

--- a/src/main/java/io/litmuschaos/util/HttpResponseHandler.java
+++ b/src/main/java/io/litmuschaos/util/HttpResponseHandler.java
@@ -2,6 +2,9 @@ package io.litmuschaos.util;
 
 import com.google.gson.Gson;
 import com.google.gson.GsonBuilder;
+import com.google.gson.JsonElement;
+import com.google.gson.JsonObject;
+import com.google.gson.JsonParser;
 import io.litmuschaos.exception.ApiException;
 import okhttp3.Response;
 
@@ -16,16 +19,6 @@ public class HttpResponseHandler {
         this.gson = new GsonBuilder().create();
     }
 
-    public <T> T handleResponse(Response response, Class<T> responseType) throws ApiException, IOException {
-        if (!response.isSuccessful()) {
-            throw new ApiException(response);
-        }
-        if (response.body() == null) {
-            return transform("", responseType);
-        }
-        return transform(response.body().string(), responseType);
-    }
-
     public <T> T handleResponse(Response response, Type responseType) throws ApiException, IOException {
         if (!response.isSuccessful()) {
             throw new ApiException(response);
@@ -36,11 +29,18 @@ public class HttpResponseHandler {
         return transform(response.body().string(), responseType);
     }
 
-    private <T> T transform(String response, Class<T> responseType) {
-        return gson.fromJson(response, responseType);
+    private <T> T transform(String responseBody, Type responseType) {
+        JsonElement jsonElement = JsonParser.parseString(responseBody);
+
+        if (jsonElement.isJsonObject()) {
+            JsonObject jsonObject = jsonElement.getAsJsonObject();
+            if (jsonObject.has("data")) {
+                JsonElement dataElement = jsonObject.get("data");
+                return gson.fromJson(dataElement.toString(), responseType);
+            }
+        }
+
+        return gson.fromJson(responseBody, responseType);
     }
 
-    private <T> T transform(String response, Type responseType) {
-        return gson.fromJson(response, responseType);
-    }
 }

--- a/src/main/java/io/litmuschaos/util/HttpResponseHandler.java
+++ b/src/main/java/io/litmuschaos/util/HttpResponseHandler.java
@@ -29,8 +29,8 @@ public class HttpResponseHandler {
         return transform(response.body().string(), responseType);
     }
 
-    private <T> T transform(String responseBody, Type responseType) {
-        return gson.fromJson(responseBody, responseType);
+    private <T> T transform(String response, Type responseType) {
+        return gson.fromJson(response, responseType);
     }
 
 }


### PR DESCRIPTION
**Removed duplicate logic in the methods of the HttpResponseHandler.**
Since `Class<T>` implements `Type`, passing `Class<T>` to a method that accepts `Type` works seamlessly. Therefore, I consolidated the methods into a single one that accepts `Type` as a parameter, reducing duplicate code.