### PR TITLE
Refactor Builder classes for request objects

### DIFF
--- a/src/main/java/io/litmuschaos/LitmusClient.java
+++ b/src/main/java/io/litmuschaos/LitmusClient.java
@@ -12,7 +12,6 @@ import io.litmuschaos.response.CapabilityResponse;
 import io.litmuschaos.response.CommonResponse;
 import io.litmuschaos.response.ListProjectsResponse;
 import io.litmuschaos.response.LoginResponse;
-
 import io.litmuschaos.response.ProjectMemberResponse;
 import io.litmuschaos.response.ProjectResponse;
 import io.litmuschaos.response.ProjectRoleResponse;
@@ -42,7 +41,10 @@ public class LitmusClient implements AutoCloseable {
     // TODO - @Suyeon Jung : host, port config to LitmusAuthConfig class
     public LoginResponse authenticate(String username, String password)
             throws IOException, LitmusApiException {
-        LoginRequest request = new LoginRequest(username, password);
+        LoginRequest request = LoginRequest.builder()
+                .username(username)
+                .password(password)
+                .build();
         LoginResponse response = httpClient.post("/login", request, LoginResponse.class);
         this.token = response.getAccessToken();
         return response;

--- a/src/main/java/io/litmuschaos/request/CreateProjectRequest.java
+++ b/src/main/java/io/litmuschaos/request/CreateProjectRequest.java
@@ -1,5 +1,6 @@
 package io.litmuschaos.request;
 
+import io.litmuschaos.util.Builder;
 import java.util.List;
 
 public class CreateProjectRequest {
@@ -8,40 +9,10 @@ public class CreateProjectRequest {
     private final String description;
     private final List<String> tags;
 
-    private CreateProjectRequest(Builder builder) {
+    private CreateProjectRequest(CreateProjectRequestBuilder builder) {
         this.projectName = builder.projectName;
         this.description = builder.description;
         this.tags = builder.tags;
-    }
-
-    public static Builder builder() {
-        return new Builder();
-    }
-
-    public static class Builder {
-
-        private String projectName;
-        private String description;
-        private List<String> tags;
-
-        public Builder projectName(String projectName) {
-            this.projectName = projectName;
-            return this;
-        }
-
-        public Builder description(String description) {
-            this.description = description;
-            return this;
-        }
-
-        public Builder tags(List<String> tags) {
-            this.tags = tags;
-            return this;
-        }
-
-        public CreateProjectRequest build() {
-            return new CreateProjectRequest(this);
-        }
     }
 
     public String getProjectName() {
@@ -54,5 +25,36 @@ public class CreateProjectRequest {
 
     public List<String> getTags() {
         return tags;
+    }
+
+    public static CreateProjectRequestBuilder builder() {
+        return new CreateProjectRequestBuilder();
+    }
+
+    public static class CreateProjectRequestBuilder implements Builder<CreateProjectRequest> {
+
+        private String projectName;
+        private String description;
+        private List<String> tags;
+
+        public CreateProjectRequestBuilder projectName(String projectName) {
+            this.projectName = projectName;
+            return this;
+        }
+
+        public CreateProjectRequestBuilder description(String description) {
+            this.description = description;
+            return this;
+        }
+
+        public CreateProjectRequestBuilder tags(List<String> tags) {
+            this.tags = tags;
+            return this;
+        }
+
+        @Override
+        public CreateProjectRequest build() {
+            return new CreateProjectRequest(this);
+        }
     }
 }

--- a/src/main/java/io/litmuschaos/request/LeaveProjectRequest.java
+++ b/src/main/java/io/litmuschaos/request/LeaveProjectRequest.java
@@ -1,36 +1,15 @@
 package io.litmuschaos.request;
 
+import io.litmuschaos.util.Builder;
+
 public class LeaveProjectRequest {
 
     private final String projectID;
     private final String userID;
 
-    private LeaveProjectRequest(Builder builder) {
+    private LeaveProjectRequest(LeaveProjectRequestBuilder builder) {
         this.projectID = builder.projectID;
         this.userID = builder.userID;
-    }
-
-    public static Builder builder() {
-        return new Builder();
-    }
-
-    public static class Builder {
-        private String projectID;
-        private String userID;
-
-        public Builder projectID(String projectID) {
-            this.projectID = projectID;
-            return this;
-        }
-
-        public Builder userID(String userID) {
-            this.userID = userID;
-            return this;
-        }
-
-        public LeaveProjectRequest build() {
-            return new LeaveProjectRequest(this);
-        }
     }
 
     public String getProjectID() {
@@ -41,4 +20,28 @@ public class LeaveProjectRequest {
         return userID;
     }
 
+    public static LeaveProjectRequestBuilder builder() {
+        return new LeaveProjectRequestBuilder();
+    }
+
+    public static class LeaveProjectRequestBuilder implements Builder<LeaveProjectRequest> {
+
+        private String projectID;
+        private String userID;
+
+        public LeaveProjectRequestBuilder projectID(String projectID) {
+            this.projectID = projectID;
+            return this;
+        }
+
+        public LeaveProjectRequestBuilder userID(String userID) {
+            this.userID = userID;
+            return this;
+        }
+
+        @Override
+        public LeaveProjectRequest build() {
+            return new LeaveProjectRequest(this);
+        }
+    }
 }

--- a/src/main/java/io/litmuschaos/request/ListProjectRequest.java
+++ b/src/main/java/io/litmuschaos/request/ListProjectRequest.java
@@ -1,51 +1,19 @@
 package io.litmuschaos.request;
 
+import io.litmuschaos.util.Builder;
+
 public class ListProjectRequest {
+
     private final Integer page;
     private final Integer limit;
     private final String sortField;
     private final Boolean createdByMe;
 
-    private ListProjectRequest(Builder builder) {
+    private ListProjectRequest(ListProjectRequestBuilder builder) {
         this.page = builder.page;
         this.limit = builder.limit;
         this.sortField = builder.sortField;
         this.createdByMe = builder.createdByMe;
-    }
-
-    public static Builder builder() {
-        return new Builder();
-    }
-
-    public static class Builder {
-        private Integer page;
-        private Integer limit;
-        private String sortField;
-        private Boolean createdByMe;
-
-        public Builder page(Integer page) {
-            this.page = page;
-            return this;
-        }
-
-        public Builder limit(Integer limit) {
-            this.limit = limit;
-            return this;
-        }
-
-        public Builder sortField(String sortField) {
-            this.sortField = sortField;
-            return this;
-        }
-
-        public Builder createdByMe(Boolean createdByMe) {
-            this.createdByMe = createdByMe;
-            return this;
-        }
-
-        public ListProjectRequest build() {
-            return new ListProjectRequest(this);
-        }
     }
 
     public Integer getPage() {
@@ -62,6 +30,43 @@ public class ListProjectRequest {
 
     public Boolean getCreatedByMe() {
         return createdByMe;
+    }
+
+    public static ListProjectRequestBuilder builder() {
+        return new ListProjectRequestBuilder();
+    }
+
+    public static class ListProjectRequestBuilder implements Builder<ListProjectRequest> {
+
+        private Integer page;
+        private Integer limit;
+        private String sortField;
+        private Boolean createdByMe;
+
+        public ListProjectRequestBuilder page(Integer page) {
+            this.page = page;
+            return this;
+        }
+
+        public ListProjectRequestBuilder limit(Integer limit) {
+            this.limit = limit;
+            return this;
+        }
+
+        public ListProjectRequestBuilder sortField(String sortField) {
+            this.sortField = sortField;
+            return this;
+        }
+
+        public ListProjectRequestBuilder createdByMe(Boolean createdByMe) {
+            this.createdByMe = createdByMe;
+            return this;
+        }
+
+        @Override
+        public ListProjectRequest build() {
+            return new ListProjectRequest(this);
+        }
     }
 }
 

--- a/src/main/java/io/litmuschaos/request/LoginRequest.java
+++ b/src/main/java/io/litmuschaos/request/LoginRequest.java
@@ -1,12 +1,38 @@
 package io.litmuschaos.request;
 
+import io.litmuschaos.util.Builder;
+
 public class LoginRequest {
 
-    private String username;
-    private String password;
+    private final String username;
+    private final String password;
 
-    public LoginRequest(String username, String password) {
-        this.username = username;
-        this.password = password;
+    private LoginRequest(LoginRequestBuilder builder) {
+        this.username = builder.username;
+        this.password = builder.password;
+    }
+
+    public static LoginRequestBuilder builder() {
+        return new LoginRequestBuilder();
+    }
+
+    public static class LoginRequestBuilder implements Builder<LoginRequest> {
+
+        private String username;
+        private String password;
+
+        public LoginRequestBuilder username(String username) {
+            this.username = username;
+            return this;
+        }
+
+        public LoginRequestBuilder password(String password) {
+            this.password = password;
+            return this;
+        }
+
+        public LoginRequest build() {
+            return new LoginRequest(this);
+        }
     }
 }

--- a/src/main/java/io/litmuschaos/request/ProjectNameRequest.java
+++ b/src/main/java/io/litmuschaos/request/ProjectNameRequest.java
@@ -1,36 +1,15 @@
 package io.litmuschaos.request;
 
+import io.litmuschaos.util.Builder;
+
 public class ProjectNameRequest {
 
     private final String projectID;
     private final String projectName;
 
-    private ProjectNameRequest(Builder builder) {
+    private ProjectNameRequest(ProjectNameRequestBuilder builder) {
         this.projectID = builder.projectID;
         this.projectName = builder.projectName;
-    }
-
-    public static Builder builder() {
-        return new Builder();
-    }
-
-    public static class Builder {
-        private String projectID;
-        private String projectName;
-
-        public Builder projectID(String projectID) {
-            this.projectID = projectID;
-            return this;
-        }
-
-        public Builder projectName(String projectName) {
-            this.projectName = projectName;
-            return this;
-        }
-
-        public ProjectNameRequest build() {
-            return new ProjectNameRequest(this);
-        }
     }
 
     public String getProjectID() {
@@ -39,5 +18,30 @@ public class ProjectNameRequest {
 
     public String getProjectName() {
         return projectName;
+    }
+
+    public static ProjectNameRequestBuilder builder() {
+        return new ProjectNameRequestBuilder();
+    }
+
+    public static class ProjectNameRequestBuilder implements Builder<ProjectNameRequest> {
+
+        private String projectID;
+        private String projectName;
+
+        public ProjectNameRequestBuilder projectID(String projectID) {
+            this.projectID = projectID;
+            return this;
+        }
+
+        public ProjectNameRequestBuilder projectName(String projectName) {
+            this.projectName = projectName;
+            return this;
+        }
+
+        @Override
+        public ProjectNameRequest build() {
+            return new ProjectNameRequest(this);
+        }
     }
 }

--- a/src/main/java/io/litmuschaos/util/Builder.java
+++ b/src/main/java/io/litmuschaos/util/Builder.java
@@ -1,0 +1,11 @@
+package io.litmuschaos.util;
+
+/**
+ * Builder interface.
+ *
+ * @param <T> the type of object to build
+ */
+public interface Builder<T> {
+
+    T build();
+}


### PR DESCRIPTION
This pull request updates the naming convention for builder classes related to project requests. The `Builder` classes have been renamed to follow a consistent format, such as `CreateProjectRequestBuilder`.

Additionally, each builder class now implements the `Builder<T>` interface with the corresponding request type, ensuring type safety and clarity. For example, the `CreateProjectRequestBuilder` now implements `Builder<CreateProjectRequest>`.

These changes enhance code readability and maintainability by providing a clearer structure for the builder pattern used in the project request types.

cc. @namkyu1999 