### PR TITLE
Add GitHub Actions continuous build

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,0 +1,63 @@
+name: Build
+
+on:
+  pull_request:
+  push:
+    branches:
+      - master
+    paths-ignore:
+      - '**.md'
+      - 'docs/**'
+  workflow_dispatch:
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.sha }}
+
+jobs:
+  build:
+    name: Build
+    runs-on: ${{ matrix.os }}
+    strategy:
+      fail-fast: false
+      matrix:
+        os:
+          - ubuntu-latest
+          - windows-latest
+          - macos-latest
+          - macos-13
+        java-version:
+          - 8
+          - 11
+          - 17
+          - 21
+          - 23
+        # macos-latest drops support for java 8 temurin. Run java 8 on macos-13. Run java 11, 17, 21, 23 on macos-latest.
+        exclude:
+          - os: macos-latest
+            java-version: 8
+          - os: macos-13
+            java-version: 11
+          - os: macos-13
+            java-version: 17
+          - os: macos-13
+            java-version: 21
+          - os: macos-13
+            java-version: 23
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Java ${{ matrix.java-version }}
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'temurin'
+          java-version: ${{ matrix.java-version }}
+          cache: 'maven'
+
+      # Generate GraphQL client codes
+      - name: Download additional sources
+        run: mvn generate-sources
+
+      - name: Build with Maven
+        run: >
+          mvn -B package
+          -DskipTests


### PR DESCRIPTION
This pull request adds a new GitHub Actions workflow configuration for building the project. The workflow is triggered on pull requests and pushes to the master branch, excluding markdown(`**.md`) and documentation files(`docs/**`). It includes a matrix strategy to build the project on different operating systems and Java versions.

Key changes include:

* Added a new workflow configuration in `.github/workflows/build.yaml` to define the build process.
* Configured the workflow to run on Ubuntu, Windows, and macOS with multiple Java versions, excluding unsupported combinations.
* Included steps to check out the repository, set up the Java environment, and build the project using Maven.

cc. @namkyu1999 