### PR TITLE
feat: refactor graphql endpoint

### DIFF
--- a/src/main/java/io/litmuschaos/LitmusClient.java
+++ b/src/main/java/io/litmuschaos/LitmusClient.java
@@ -457,11 +457,11 @@ public class LitmusClient implements AutoCloseable {
      * @param query
      * @param projectionRoot
      * @return Returns the environment.
+     * @throws LitmusApiException
      */
-    public Environment getEnvironment(GetEnvironmentGraphQLQuery query, GetEnvironmentProjectionRoot projectionRoot){
+    public Environment getEnvironment(GetEnvironmentGraphQLQuery query, GetEnvironmentProjectionRoot projectionRoot) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query, projectionRoot).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(GET_ENVIRONMENT, new TypeRef<Environment>(){});
+        return graphQLClient.query(request, GET_ENVIRONMENT, new TypeRef<Environment>(){});
     }
 
     /**
@@ -470,11 +470,11 @@ public class LitmusClient implements AutoCloseable {
      * @param query
      * @param projectionRoot
      * @return Returns the list of environments.
+     * @throws LitmusApiException
      */
-    public ListEnvironmentResponse listEnvironments(ListEnvironmentsGraphQLQuery query, ListEnvironmentsProjectionRoot projectionRoot){
+    public ListEnvironmentResponse listEnvironments(ListEnvironmentsGraphQLQuery query, ListEnvironmentsProjectionRoot projectionRoot) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query, projectionRoot).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(LIST_ENVIRONMENTS, new TypeRef<ListEnvironmentResponse>(){});
+        return graphQLClient.query(request, LIST_ENVIRONMENTS, new TypeRef<ListEnvironmentResponse>(){});
     }
 
     /**
@@ -483,11 +483,11 @@ public class LitmusClient implements AutoCloseable {
      * @param query
      * @param projectionRoot
      * @return Returns the created environment.
+     * @throws LitmusApiException
      */
-    public Environment createEnvironment(CreateEnvironmentGraphQLQuery query, CreateEnvironmentProjectionRoot projectionRoot){
+    public Environment createEnvironment(CreateEnvironmentGraphQLQuery query, CreateEnvironmentProjectionRoot projectionRoot) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query, projectionRoot).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(CREATE_ENVIRONMENT, new TypeRef<Environment>(){});
+        return graphQLClient.query(request, CREATE_ENVIRONMENT, new TypeRef<Environment>(){});
     }
 
     /**
@@ -495,23 +495,24 @@ public class LitmusClient implements AutoCloseable {
      *
      * @param query
      * @return Returns the response of the delete environment request.
+     * @throws LitmusApiException
      */
-    public DeleteEnvironmentResponse deleteEnvironment(DeleteEnvironmentGraphQLQuery query){
+    public DeleteEnvironmentResponse deleteEnvironment(DeleteEnvironmentGraphQLQuery query) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(DELETE_ENVIRONMENT, new TypeRef<DeleteEnvironmentResponse>(){});
+        return graphQLClient.query(request, DELETE_ENVIRONMENT, new TypeRef<DeleteEnvironmentResponse>(){});
     }
+
 
     /**
      * Update the environment.
      *
      * @param query
      * @return Returns the updated environment.
+     * @throws LitmusApiException
      */
-    public UpdateEnvironmentResponse updateEnvironment(UpdateEnvironmentGraphQLQuery query){
+    public UpdateEnvironmentResponse updateEnvironment(UpdateEnvironmentGraphQLQuery query) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(UPDATE_ENVIRONMENT, new TypeRef<UpdateEnvironmentResponse>(){});
+        return graphQLClient.query(request, UPDATE_ENVIRONMENT, new TypeRef<UpdateEnvironmentResponse>(){});
     }
 
     /**
@@ -521,10 +522,9 @@ public class LitmusClient implements AutoCloseable {
      * @param projectionRoot
      * @return Returns the infra.
      */
-    public Infra getInfra(GetInfraGraphQLQuery query, GetInfraProjectionRoot projectionRoot){
+    public Infra getInfra(GetInfraGraphQLQuery query, GetInfraProjectionRoot projectionRoot) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query, projectionRoot).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(GET_INFRA, new TypeRef<Infra>(){});
+        return graphQLClient.query(request, GET_INFRA, new TypeRef<Infra>(){});
     }
 
     /**
@@ -533,11 +533,11 @@ public class LitmusClient implements AutoCloseable {
      * @param query
      * @param projectionRoot
      * @return Returns the list of infras.
+     * @throws LitmusApiException
      */
-    public ListInfraResponse listInfras(ListInfrasGraphQLQuery query, ListInfrasProjectionRoot projectionRoot) {
+    public ListInfraResponse listInfras(ListInfrasGraphQLQuery query, ListInfrasProjectionRoot projectionRoot) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query, projectionRoot).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(LIST_INFRAS, new TypeRef<ListInfraResponse>() {});
+        return graphQLClient.query(request, LIST_INFRAS, new TypeRef<ListInfraResponse>(){});
     }
 
     /**
@@ -546,11 +546,11 @@ public class LitmusClient implements AutoCloseable {
      * @param query
      * @param projectionRoot
      * @return Returns the infra details.
+     * @throws LitmusApiException
      */
-    public Infra getInfraDetails(GetInfraDetailsGraphQLQuery query, GetInfraDetailsProjectionRoot projectionRoot){
+    public Infra getInfraDetails(GetInfraDetailsGraphQLQuery query, GetInfraDetailsProjectionRoot projectionRoot) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query, projectionRoot).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(GET_INFRA_DETAILS, new TypeRef<Infra>(){});
+        return graphQLClient.query(request, GET_INFRA_DETAILS, new TypeRef<Infra>(){});
     }
 
     /**
@@ -559,11 +559,11 @@ public class LitmusClient implements AutoCloseable {
      * @param query
      * @param projectionRoot
      * @return Returns the infra stats.
+     * @throws LitmusApiException
      */
-    public GetInfraStatsResponse getInfraStats(GetInfraStatsGraphQLQuery query, GetInfraStatsProjectionRoot projectionRoot){
+    public GetInfraStatsResponse getInfraStats(GetInfraStatsGraphQLQuery query, GetInfraStatsProjectionRoot projectionRoot) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query, projectionRoot).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(GET_INFRA_STATS, new TypeRef<GetInfraStatsResponse>(){});
+        return graphQLClient.query(request, GET_INFRA_STATS, new TypeRef<GetInfraStatsResponse>(){});
     }
 
     /**
@@ -571,11 +571,11 @@ public class LitmusClient implements AutoCloseable {
      *
      * @param query
      * @return Returns the infra manifest.
+     * @throws LitmusApiException
      */
-    public GetInfraManifestResponse getInfraManifest(GetInfraManifestGraphQLQuery query){
+    public GetInfraManifestResponse getInfraManifest(GetInfraManifestGraphQLQuery query) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(GET_INFRA_MANIFEST, new TypeRef<GetInfraManifestResponse>(){});
+        return graphQLClient.query(request, GET_INFRA_MANIFEST, new TypeRef<GetInfraManifestResponse>(){});
     }
 
     /**
@@ -584,11 +584,11 @@ public class LitmusClient implements AutoCloseable {
      * @param query
      * @param projectionRoot
      * @return Returns the response of the confirm infra registration request.
+     * @throws LitmusApiException
      */
-    public ConfirmInfraRegistrationResponse confirmInfraRegistration(ConfirmInfraRegistrationGraphQLQuery query, ConfirmInfraRegistrationProjectionRoot projectionRoot){
+    public ConfirmInfraRegistrationResponse confirmInfraRegistration(ConfirmInfraRegistrationGraphQLQuery query, ConfirmInfraRegistrationProjectionRoot projectionRoot) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query, projectionRoot).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(CONFIRM_INFRA_REGISTRATION, new TypeRef<ConfirmInfraRegistrationResponse>(){});
+        return graphQLClient.query(request, CONFIRM_INFRA_REGISTRATION, new TypeRef<ConfirmInfraRegistrationResponse>(){});
     }
 
     /**
@@ -596,11 +596,11 @@ public class LitmusClient implements AutoCloseable {
      *
      * @param query
      * @return Returns the response of the delete infra request.
+     * @throws LitmusApiException
      */
-    public DeleteInfraResponse deleteInfra(DeleteInfraGraphQLQuery query){
+    public DeleteInfraResponse deleteInfra(DeleteInfraGraphQLQuery query) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(DELETE_INFRA, new TypeRef<DeleteInfraResponse>(){});
+        return graphQLClient.query(request, DELETE_INFRA, new TypeRef<DeleteInfraResponse>(){});
     }
 
     /**
@@ -609,11 +609,11 @@ public class LitmusClient implements AutoCloseable {
      * @param query
      * @param projectionRoot
      * @return Returns the response of the register infra request.
+     * @throws LitmusApiException
      */
-    public RegisterInfraResponse registerInfra(RegisterInfraGraphQLQuery query, RegisterInfraProjectionRoot projectionRoot){
+    public RegisterInfraResponse registerInfra(RegisterInfraGraphQLQuery query, RegisterInfraProjectionRoot projectionRoot) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query, projectionRoot).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(REGISTER_INFRA, new TypeRef<RegisterInfraResponse>(){});
+        return graphQLClient.query(request, REGISTER_INFRA, new TypeRef<RegisterInfraResponse>(){});
     }
 
     /**
@@ -622,11 +622,11 @@ public class LitmusClient implements AutoCloseable {
      * @param query
      * @param projectionRoot
      * @return Returns the list of chaos hubs.
+     * @throws LitmusApiException
      */
-    public List<ChaosHubStatus> listChaosHub(ListChaosHubGraphQLQuery query, ListChaosHubProjectionRoot projectionRoot){
+    public List<ChaosHubStatus> listChaosHub(ListChaosHubGraphQLQuery query, ListChaosHubProjectionRoot projectionRoot) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query, projectionRoot).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(LIST_CHAOS_HUB, new TypeRef<List<ChaosHubStatus>>(){});
+        return graphQLClient.query(request, LIST_CHAOS_HUB, new TypeRef<List<ChaosHubStatus>>(){});
     }
 
     /**
@@ -635,11 +635,11 @@ public class LitmusClient implements AutoCloseable {
      * @param query
      * @param projectionRoot
      * @return Returns the chaos hub.
+     * @throws LitmusApiException
      */
-    public ChaosHubStatus getChaosHub(GetChaosHubGraphQLQuery query, GetChaosHubProjectionRoot projectionRoot){
+    public ChaosHubStatus getChaosHub(GetChaosHubGraphQLQuery query, GetChaosHubProjectionRoot projectionRoot) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query, projectionRoot).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(GET_CHAOS_HUB, new TypeRef<ChaosHubStatus>() {});
+        return graphQLClient.query(request, GET_CHAOS_HUB, new TypeRef<ChaosHubStatus>() {});
     }
 
     /**
@@ -648,11 +648,11 @@ public class LitmusClient implements AutoCloseable {
      * @param query
      * @param projectionRoot
      * @return Returns the chaos hub stats.
+     * @throws LitmusApiException
      */
-    public GetChaosHubStatsResponse getChaosHubStats(GetChaosHubStatsGraphQLQuery query, GetChaosHubStatsProjectionRoot projectionRoot){
+    public GetChaosHubStatsResponse getChaosHubStats(GetChaosHubStatsGraphQLQuery query, GetChaosHubStatsProjectionRoot projectionRoot) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query, projectionRoot).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(GET_CHAOS_HUB_STATS, new TypeRef<GetChaosHubStatsResponse>() {});
+        return graphQLClient.query(request, GET_CHAOS_HUB_STATS, new TypeRef<GetChaosHubStatsResponse>() {});
     }
 
     /**
@@ -661,11 +661,11 @@ public class LitmusClient implements AutoCloseable {
      * @param query
      * @param projectionRoot
      * @return Returns the added chaos hub.
+     * @throws LitmusApiException
      */
-    public ChaosHub addChaosHub(AddChaosHubGraphQLQuery query, AddChaosHubProjectionRoot projectionRoot){
+    public ChaosHub addChaosHub(AddChaosHubGraphQLQuery query, AddChaosHubProjectionRoot projectionRoot) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query, projectionRoot).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(ADD_CHAOS_HUB, new TypeRef<ChaosHub>(){});
+        return graphQLClient.query(request, ADD_CHAOS_HUB, new TypeRef<ChaosHub>() {});
     }
 
     /**
@@ -674,11 +674,11 @@ public class LitmusClient implements AutoCloseable {
      * @param query
      * @param projectionRoot
      * @return Returns the added remote chaos hub.
+     * @throws LitmusApiException
      */
-    public ChaosHub addRemoteChaosHub(AddRemoteChaosHubGraphQLQuery query, AddRemoteChaosHubProjectionRoot projectionRoot){
+    public ChaosHub addRemoteChaosHub(AddRemoteChaosHubGraphQLQuery query, AddRemoteChaosHubProjectionRoot projectionRoot) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query, projectionRoot).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(ADD_REMOTE_CHAOS_HUB, new TypeRef<ChaosHub>() {});
+        return graphQLClient.query(request, ADD_REMOTE_CHAOS_HUB, new TypeRef<ChaosHub>() {});
     }
 
     /**
@@ -686,11 +686,11 @@ public class LitmusClient implements AutoCloseable {
      *
      * @param query
      * @return Returns the response of the delete chaos hub request.
+     * @throws LitmusApiException
      */
-    public DeleteChaosHubResponse deleteChaosHub(DeleteChaosHubGraphQLQuery query){
+    public DeleteChaosHubResponse deleteChaosHub(DeleteChaosHubGraphQLQuery query) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(DELETE_CHAOS_HUB, new TypeRef<DeleteChaosHubResponse>(){});
+        return graphQLClient.query(request, DELETE_CHAOS_HUB, new TypeRef<DeleteChaosHubResponse>(){});
     }
 
     /**
@@ -699,11 +699,11 @@ public class LitmusClient implements AutoCloseable {
      * @param query
      * @param projectionRoot
      * @return Returns the saved chaos hub.
+     * @throws LitmusApiException
      */
-    public ChaosHub saveChaosHub(SaveChaosHubGraphQLQuery query, SaveChaosHubProjectionRoot projectionRoot){
+    public ChaosHub saveChaosHub(SaveChaosHubGraphQLQuery query, SaveChaosHubProjectionRoot projectionRoot) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query, projectionRoot).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(SAVE_CHAOS_HUB, new TypeRef<ChaosHub>() {});
+        return graphQLClient.query(request, SAVE_CHAOS_HUB, new TypeRef<ChaosHub>() {});
     }
 
     /**
@@ -711,11 +711,11 @@ public class LitmusClient implements AutoCloseable {
      *
      * @param query
      * @return Returns the response of the sync chaos hub request.
+     * @throws LitmusApiException
      */
-    public SyncChaosHubResponse syncChaosHub(SyncChaosHubGraphQLQuery query){
+    public SyncChaosHubResponse syncChaosHub(SyncChaosHubGraphQLQuery query) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(SYNC_CHAOS_HUB, new TypeRef<SyncChaosHubResponse>() {});
+        return graphQLClient.query(request, SYNC_CHAOS_HUB, new TypeRef<SyncChaosHubResponse>() {});
     }
 
     /**
@@ -724,11 +724,11 @@ public class LitmusClient implements AutoCloseable {
      * @param query
      * @param projectionRoot
      * @return Returns the updated chaos hub.
+     * @throws LitmusApiException
      */
-    public ChaosHub updateChaosHub(UpdateChaosHubGraphQLQuery query, UpdateChaosHubProjectionRoot projectionRoot){
+    public ChaosHub updateChaosHub(UpdateChaosHubGraphQLQuery query, UpdateChaosHubProjectionRoot projectionRoot) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query, projectionRoot).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(UPDATE_CHAOS_HUB, new TypeRef<ChaosHub>() {});
+        return graphQLClient.query(request, UPDATE_CHAOS_HUB, new TypeRef<ChaosHub>() {});
     }
 
     /**
@@ -737,11 +737,11 @@ public class LitmusClient implements AutoCloseable {
      * @param query
      * @param projectionRoot
      * @return Returns the chaos experiment.
+     * @throws LitmusApiException
      */
-    public GetExperimentResponse getExperiment(GetExperimentGraphQLQuery query, GetExperimentProjectionRoot projectionRoot){
+    public GetExperimentResponse getExperiment(GetExperimentGraphQLQuery query, GetExperimentProjectionRoot projectionRoot) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query, projectionRoot).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(GET_EXPERIMENT, new TypeRef<GetExperimentResponse>(){});
+        return graphQLClient.query(request, GET_EXPERIMENT, new TypeRef<GetExperimentResponse>(){});
     }
 
     /**
@@ -750,11 +750,11 @@ public class LitmusClient implements AutoCloseable {
      * @param query
      * @param projectionRoot
      * @return Returns the list of chaos experiments.
+     * @throws LitmusApiException
      */
-    public ListExperimentResponse listExperiment(ListExperimentGraphQLQuery query, ListExperimentProjectionRoot projectionRoot){
+    public ListExperimentResponse listExperiment(ListExperimentGraphQLQuery query, ListExperimentProjectionRoot projectionRoot) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query, projectionRoot).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(LIST_EXPERIMENT, new TypeRef<ListExperimentResponse>(){});
+        return graphQLClient.query(request, LIST_EXPERIMENT, new TypeRef<ListExperimentResponse>(){});
     }
 
     /**
@@ -763,11 +763,11 @@ public class LitmusClient implements AutoCloseable {
      * @param query
      * @param projectionRoot
      * @return Returns the chaos experiment stats.
+     * @throws LitmusApiException
      */
-    public GetExperimentStatsResponse getExperimentStats(GetExperimentStatsGraphQLQuery query, GetExperimentStatsProjectionRoot projectionRoot){
+    public GetExperimentStatsResponse getExperimentStats(GetExperimentStatsGraphQLQuery query, GetExperimentStatsProjectionRoot projectionRoot) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query, projectionRoot).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(GET_EXPERIMENT_STATS, new TypeRef<GetExperimentStatsResponse>(){});
+        return graphQLClient.query(request, GET_EXPERIMENT_STATS, new TypeRef<GetExperimentStatsResponse>(){});
     }
 
     /**
@@ -776,11 +776,11 @@ public class LitmusClient implements AutoCloseable {
      * @param query
      * @param projectionRoot
      * @return Returns the predefined chaos experiment.
+     * @throws LitmusApiException
      */
-    public List<PredefinedExperimentList> getPredefinedExperiment(GetPredefinedExperimentGraphQLQuery query, GetPredefinedExperimentProjectionRoot projectionRoot){
+    public List<PredefinedExperimentList> getPredefinedExperiment(GetPredefinedExperimentGraphQLQuery query, GetPredefinedExperimentProjectionRoot projectionRoot) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query, projectionRoot).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(GET_PREDEFINED_EXPERIMENT, new TypeRef<List<PredefinedExperimentList>>(){});
+        return graphQLClient.query(request, GET_PREDEFINED_EXPERIMENT, new TypeRef<List<PredefinedExperimentList>>(){});
     }
 
     /**
@@ -789,11 +789,11 @@ public class LitmusClient implements AutoCloseable {
      * @param query
      * @param projectionRoot
      * @return Returns the list of predefined chaos experiments.
+     * @throws LitmusApiException
      */
-    public List<PredefinedExperimentList> listPredefinedExperiments(ListPredefinedExperimentsGraphQLQuery query, ListPredefinedExperimentsProjectionRoot projectionRoot){
+    public List<PredefinedExperimentList> listPredefinedExperiments(ListPredefinedExperimentsGraphQLQuery query, ListPredefinedExperimentsProjectionRoot projectionRoot) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query, projectionRoot).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(LIST_PREDEFINED_EXPERIMENTS, new TypeRef<List<PredefinedExperimentList>>(){});
+        return graphQLClient.query(request, LIST_PREDEFINED_EXPERIMENTS, new TypeRef<List<PredefinedExperimentList>>(){});
     }
 
     /**
@@ -801,23 +801,24 @@ public class LitmusClient implements AutoCloseable {
      * @param query
      * @param projectionRoot
      * @return Returns the response of the run chaos experiment request.
+     * @throws LitmusApiException
      */
-    public RunChaosExperimentResponse runChaosExperiment(RunChaosExperimentGraphQLQuery query, RunChaosExperimentProjectionRoot projectionRoot){
+    public RunChaosExperimentResponse runChaosExperiment(RunChaosExperimentGraphQLQuery query, RunChaosExperimentProjectionRoot projectionRoot) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query, projectionRoot).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(RUN_CHAOS_EXPERIMENT, new TypeRef<RunChaosExperimentResponse>(){});
+        return graphQLClient.query(request, RUN_CHAOS_EXPERIMENT, new TypeRef<RunChaosExperimentResponse>(){});
     }
+
 
     /**
      * Save the chaos experiment.
      *
      * @param query
      * @return Returns the response of the save chaos experiment request.
+     * @throws LitmusApiException
      */
-    public SaveChaosExperimentResponse saveChaosExperiment(SaveChaosExperimentGraphQLQuery query){
+    public SaveChaosExperimentResponse saveChaosExperiment(SaveChaosExperimentGraphQLQuery query) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(SAVE_CHAOS_EXPERIMENT, new TypeRef<SaveChaosExperimentResponse>(){});
+        return graphQLClient.query(request, SAVE_CHAOS_EXPERIMENT, new TypeRef<SaveChaosExperimentResponse>(){});
     }
 
     /**
@@ -826,11 +827,11 @@ public class LitmusClient implements AutoCloseable {
      * @param query
      * @param projectionRoot
      * @return Returns the updated chaos experiment.
+     * @throws LitmusApiException
      */
-    public ChaosExperimentResponse updateChaosExperiment(UpdateChaosExperimentGraphQLQuery query, UpdateChaosExperimentProjectionRoot projectionRoot){
+    public ChaosExperimentResponse updateChaosExperiment(UpdateChaosExperimentGraphQLQuery query, UpdateChaosExperimentProjectionRoot projectionRoot) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query, projectionRoot).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(UPDATE_CHAOS_EXPERIMENT, new TypeRef<ChaosExperimentResponse>(){});
+        return graphQLClient.query(request, UPDATE_CHAOS_EXPERIMENT, new TypeRef<ChaosExperimentResponse>(){});
     }
 
     /**
@@ -839,11 +840,11 @@ public class LitmusClient implements AutoCloseable {
      * @param query
      * @param projectionRoot
      * @return Returns the created chaos experiment.
+     * @throws LitmusApiException
      */
-    public ChaosExperimentResponse createChaosExperiment(CreateChaosExperimentGraphQLQuery query, CreateChaosExperimentProjectionRoot projectionRoot){
+    public ChaosExperimentResponse createChaosExperiment(CreateChaosExperimentGraphQLQuery query, CreateChaosExperimentProjectionRoot projectionRoot) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query, projectionRoot).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(CREATE_CHAOS_EXPERIMENT, new TypeRef<ChaosExperimentResponse>(){});
+        return graphQLClient.query(request, CREATE_CHAOS_EXPERIMENT, new TypeRef<ChaosExperimentResponse>(){});
     }
 
     /**
@@ -851,11 +852,11 @@ public class LitmusClient implements AutoCloseable {
      *
      * @param query
      * @return Returns the response of the delete chaos experiment request.
+     * @throws LitmusApiException
      */
-    public DeleteChaosExperimentResponse deleteChaosExperiment(DeleteChaosExperimentGraphQLQuery query){
+    public DeleteChaosExperimentResponse deleteChaosExperiment(DeleteChaosExperimentGraphQLQuery query) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(DELETE_CHAOS_EXPERIMENT, new TypeRef<DeleteChaosExperimentResponse>(){});
+        return graphQLClient.query(request, DELETE_CHAOS_EXPERIMENT, new TypeRef<DeleteChaosExperimentResponse>(){});
     }
 
     /**
@@ -863,10 +864,9 @@ public class LitmusClient implements AutoCloseable {
      * @param query
      * @return Returns the response of the update cron chaos experiment state request.
      */
-    public UpdateCronExperimentStateResponse updateCronExperimentState(UpdateCronExperimentStateGraphQLQuery query){
+    public UpdateCronExperimentStateResponse updateCronExperimentState(UpdateCronExperimentStateGraphQLQuery query) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(UPDATE_CRON_EXPERIMENT_STATE, new TypeRef<UpdateCronExperimentStateResponse>(){});
+        return graphQLClient.query(request, UPDATE_CRON_EXPERIMENT_STATE, new TypeRef<UpdateCronExperimentStateResponse>(){});
     }
 
     /**
@@ -875,11 +875,11 @@ public class LitmusClient implements AutoCloseable {
      * @param query
      * @param projectionRoot
      * @return Returns the chaos experiment run.
+     * @throws LitmusApiException
      */
-    public ExperimentRun getExperimentRun(GetExperimentRunGraphQLQuery query, GetExperimentRunProjectionRoot projectionRoot){
+    public ExperimentRun getExperimentRun(GetExperimentRunGraphQLQuery query, GetExperimentRunProjectionRoot projectionRoot) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query, projectionRoot).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(GET_EXPERIMENT_RUN, new TypeRef<ExperimentRun>(){});
+        return graphQLClient.query(request, GET_EXPERIMENT_RUN, new TypeRef<ExperimentRun>(){});
     }
 
     /**
@@ -888,11 +888,11 @@ public class LitmusClient implements AutoCloseable {
      * @param query
      * @param projectionRoot
      * @return Returns the chaos experiment run stats.
+     * @throws LitmusApiException
      */
-    public GetExperimentRunStatsResponse getExperimentRunStats(GetExperimentRunStatsGraphQLQuery query, GetExperimentRunStatsProjectionRoot projectionRoot){
+    public GetExperimentRunStatsResponse getExperimentRunStats(GetExperimentRunStatsGraphQLQuery query, GetExperimentRunStatsProjectionRoot projectionRoot) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query, projectionRoot).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(GET_EXPERIMENT_RUN_STATS, new TypeRef<GetExperimentRunStatsResponse>(){});
+        return graphQLClient.query(request, GET_EXPERIMENT_RUN_STATS, new TypeRef<GetExperimentRunStatsResponse>(){});
     }
 
     /**
@@ -901,35 +901,37 @@ public class LitmusClient implements AutoCloseable {
      * @param query
      * @param projectionRoot
      * @return Returns the list of chaos experiment runs.
+     * @throws LitmusApiException
      */
-    public ListExperimentRunResponse listExperimentRun(ListExperimentRunGraphQLQuery query, ListExperimentRunProjectionRoot projectionRoot){
+    public ListExperimentRunResponse listExperimentRun(ListExperimentRunGraphQLQuery query, ListExperimentRunProjectionRoot projectionRoot) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query, projectionRoot).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(LIST_EXPERIMENT_RUN, new TypeRef<ListExperimentRunResponse>(){});
+        return graphQLClient.query(request, LIST_EXPERIMENT_RUN, new TypeRef<ListExperimentRunResponse>(){});
     }
+
 
     /**
      * Creates a new experiment run and sends it to subscriber
      *
      * @param query
      * @return Returns the response of the chaos experiment run request.
+     * @throws LitmusApiException
      */
-    public ChaosExperimentRunResponse chaosExperimentRun(ChaosExperimentRunGraphQLQuery query){
+    public ChaosExperimentRunResponse chaosExperimentRun(ChaosExperimentRunGraphQLQuery query) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(CHAOS_EXPERIMENT_RUN, new TypeRef<ChaosExperimentRunResponse>(){});
+        return graphQLClient.query(request, CHAOS_EXPERIMENT_RUN, new TypeRef<ChaosExperimentRunResponse>(){});
     }
+
 
     /**
      * Stop the chaos experiment run.
      *
      * @param query
      * @return Returns the response of the stop chaos experiment run request.
+     * @throws LitmusApiException
      */
-    public StopExperimentRunsResponse stopExperimentRuns(StopExperimentRunsGraphQLQuery query){
+    public StopExperimentRunsResponse stopExperimentRuns(StopExperimentRunsGraphQLQuery query) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(STOP_EXPERIMENT_RUNS, new TypeRef<StopExperimentRunsResponse>(){});
+        return graphQLClient.query(request, STOP_EXPERIMENT_RUNS, new TypeRef<StopExperimentRunsResponse>(){});
     }
 
     /**
@@ -938,11 +940,11 @@ public class LitmusClient implements AutoCloseable {
      * @param query
      * @param projectionRoot
      * @return Returns the git configuration for gitops
+     * @throws LitmusApiException
      */
-    public GitConfigResponse getGitOpsDetails(GetGitOpsDetailsGraphQLQuery query, GetGitOpsDetailsProjectionRoot projectionRoot){
+    public GitConfigResponse getGitOpsDetails(GetGitOpsDetailsGraphQLQuery query, GetGitOpsDetailsProjectionRoot projectionRoot) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query, projectionRoot).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(GET_GIT_OPS_DETAILS, new TypeRef<GitConfigResponse>(){});
+        return graphQLClient.query(request, GET_GIT_OPS_DETAILS, new TypeRef<GitConfigResponse>(){});
     }
 
     /**
@@ -950,23 +952,22 @@ public class LitmusClient implements AutoCloseable {
      *
      * @param query
      * @return Returns the response of the disable gitops request.
+     * @throws LitmusApiException
      */
-    public DisableGitOpsResponse disableGitOps(DisableGitOpsGraphQLQuery query){
+    public DisableGitOpsResponse disableGitOps(DisableGitOpsGraphQLQuery query) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(DISABLE_GIT_OPS, new TypeRef<DisableGitOpsResponse>(){});
+        return graphQLClient.query(request, DISABLE_GIT_OPS, new TypeRef<DisableGitOpsResponse>(){});
     }
-
     /**
      * Enables gitops settings in the project
      *
      * @param query
      * @return Returns the response of the enable gitops request.
+     * @throws LitmusApiException
      */
-    public EnableGitOpsResponse enableGitOps(EnableGitOpsGraphQLQuery query){
+    public EnableGitOpsResponse enableGitOps(EnableGitOpsGraphQLQuery query) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(ENABLE_GIT_OPS, new TypeRef<EnableGitOpsResponse>(){});
+        return graphQLClient.query(request, ENABLE_GIT_OPS, new TypeRef<EnableGitOpsResponse>(){});
     }
 
     /**
@@ -974,11 +975,11 @@ public class LitmusClient implements AutoCloseable {
      *
      * @param query
      * @return Returns the response of the gitops notifier request.
+     * @throws LitmusApiException
      */
-    public GitOpsNotifierResponse gitopsNotifier(GitopsNotifierGraphQLQuery query){
+    public GitOpsNotifierResponse gitopsNotifier(GitopsNotifierGraphQLQuery query) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(GITOPS_NOTIFIER, new TypeRef<GitOpsNotifierResponse>(){});
+        return graphQLClient.query(request, GITOPS_NOTIFIER, new TypeRef<GitOpsNotifierResponse>(){});
     }
 
     /**
@@ -986,12 +987,13 @@ public class LitmusClient implements AutoCloseable {
      *
      * @param query
      * @return Returns the response of the update gitops request.
+     * @throws LitmusApiException
      */
-    public UpdateGitOpsResponse updateGitOps(UpdateGitOpsGraphQLQuery query){
+    public UpdateGitOpsResponse updateGitOps(UpdateGitOpsGraphQLQuery query) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(UPDATE_GIT_OPS, new TypeRef<UpdateGitOpsResponse>(){});
+        return graphQLClient.query(request, UPDATE_GIT_OPS, new TypeRef<UpdateGitOpsResponse>(){});
     }
+
 
     /**
      * Get the image registry.
@@ -999,11 +1001,11 @@ public class LitmusClient implements AutoCloseable {
      * @param query
      * @param projectionRoot
      * @return Returns the image registry.
+     * @throws LitmusApiException
      */
-    public ImageRegistryResponse getImageRegistry(GetImageRegistryGraphQLQuery query, GetImageRegistryProjectionRoot projectionRoot){
+    public ImageRegistryResponse getImageRegistry(GetImageRegistryGraphQLQuery query, GetImageRegistryProjectionRoot projectionRoot) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query, projectionRoot).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(GET_IMAGE_REGISTRY, new TypeRef<ImageRegistryResponse>(){});
+        return graphQLClient.query(request, GET_IMAGE_REGISTRY, new TypeRef<ImageRegistryResponse>(){});
     }
 
     /**
@@ -1012,11 +1014,11 @@ public class LitmusClient implements AutoCloseable {
      * @param query
      * @param projectionRoot
      * @return Returns the list of image registries.
+     * @throws LitmusApiException
      */
-    public List<ImageRegistryResponse> listImageRegistry(ListImageRegistryGraphQLQuery query, ListImageRegistryProjectionRoot projectionRoot){
+    public List<ImageRegistryResponse> listImageRegistry(ListImageRegistryGraphQLQuery query, ListImageRegistryProjectionRoot projectionRoot) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query, projectionRoot).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(LIST_IMAGE_REGISTRY, new TypeRef<List<ImageRegistryResponse>>(){});
+        return graphQLClient.query(request, LIST_IMAGE_REGISTRY, new TypeRef<List<ImageRegistryResponse>>(){});
     }
 
     /**
@@ -1025,23 +1027,24 @@ public class LitmusClient implements AutoCloseable {
      * @param query
      * @param projectionRoot
      * @return Returns the created image registry.
+     * @throws LitmusApiException
      */
-    public ImageRegistryResponse createImageRegistry(CreateImageRegistryGraphQLQuery query, CreateImageRegistryProjectionRoot projectionRoot){
+    public ImageRegistryResponse createImageRegistry(CreateImageRegistryGraphQLQuery query, CreateImageRegistryProjectionRoot projectionRoot) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query, projectionRoot).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(CREATE_IMAGE_REGISTRY, new TypeRef<ImageRegistryResponse>(){});
+        return graphQLClient.query(request, CREATE_IMAGE_REGISTRY, new TypeRef<ImageRegistryResponse>(){});
     }
+
 
     /**
      * Delete the image registry.
      *
      * @param query
      * @return Returns the response of the delete image registry request.
+     * @throws LitmusApiException
      */
-    public DeleteImageRegistryResponse deleteImageRegistry(DeleteImageRegistryGraphQLQuery query){
+    public DeleteImageRegistryResponse deleteImageRegistry(DeleteImageRegistryGraphQLQuery query) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(DELETE_IMAGE_REGISTRY, new TypeRef<DeleteImageRegistryResponse>(){});
+        return graphQLClient.query(request, DELETE_IMAGE_REGISTRY, new TypeRef<DeleteImageRegistryResponse>(){});
     }
 
     /**
@@ -1050,11 +1053,11 @@ public class LitmusClient implements AutoCloseable {
      * @param query
      * @param projectionRoot
      * @return Returns the updated image registry.
+     * @throws LitmusApiException
      */
-    public ImageRegistryResponse updateImageRegistry(UpdateImageRegistryGraphQLQuery query, UpdateImageRegistryProjectionRoot projectionRoot){
+    public ImageRegistryResponse updateImageRegistry(UpdateImageRegistryGraphQLQuery query, UpdateImageRegistryProjectionRoot projectionRoot) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query, projectionRoot).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(UPDATE_IMAGE_REGISTRY, new TypeRef<ImageRegistryResponse>(){});
+        return graphQLClient.query(request, UPDATE_IMAGE_REGISTRY, new TypeRef<ImageRegistryResponse>(){});
     }
 
     /**
@@ -1063,11 +1066,11 @@ public class LitmusClient implements AutoCloseable {
      * @param query
      * @param projectionRoot
      * @return Returns the list of Probes
+     * @throws LitmusApiException
      */
-    public List<Probe> listProbes(ListProbesGraphQLQuery query, ListProbesProjectionRoot projectionRoot){
+    public List<Probe> listProbes(ListProbesGraphQLQuery query, ListProbesProjectionRoot projectionRoot) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query, projectionRoot).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(LIST_PROBES, new TypeRef<List<Probe>>(){});
+        return graphQLClient.query(request, LIST_PROBES, new TypeRef<List<Probe>>(){});
     }
 
     /**
@@ -1076,11 +1079,11 @@ public class LitmusClient implements AutoCloseable {
      * @param query
      * @param projectionRoot
      * @return Returns the Probe
+     * @throws LitmusApiException
      */
-    public Probe getProbe(GetProbeGraphQLQuery query, GetProbeProjectionRoot projectionRoot){
+    public Probe getProbe(GetProbeGraphQLQuery query, GetProbeProjectionRoot projectionRoot) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query, projectionRoot).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(GET_PROBE, new TypeRef<Probe>(){});
+        return graphQLClient.query(request, GET_PROBE, new TypeRef<Probe>(){});
     }
 
     /**
@@ -1088,11 +1091,11 @@ public class LitmusClient implements AutoCloseable {
      *
      * @param query
      * @return Returns the response of the validate unique probe request
+     * @throws LitmusApiException
      */
-    public ValidateUniqueProbeResponse validateUniqueProbe(ValidateUniqueProbeGraphQLQuery query){
+    public ValidateUniqueProbeResponse validateUniqueProbe(ValidateUniqueProbeGraphQLQuery query) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(VALIDATE_UNIQUE_PROBE, new TypeRef<ValidateUniqueProbeResponse>(){});
+        return graphQLClient.query(request, VALIDATE_UNIQUE_PROBE, new TypeRef<ValidateUniqueProbeResponse>(){});
     }
 
     /**
@@ -1101,11 +1104,11 @@ public class LitmusClient implements AutoCloseable {
      * @param query
      * @param projectionRoot
      * @return Returns the response of the get probe reference request
+     * @throws LitmusApiException
      */
-    public GetProbeReferenceResponse getProbeReference(GetProbeReferenceGraphQLQuery query, GetProbeReferenceProjectionRoot projectionRoot){
+    public GetProbeReferenceResponse getProbeReference(GetProbeReferenceGraphQLQuery query, GetProbeReferenceProjectionRoot projectionRoot) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query, projectionRoot).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(GET_PROBE_REFERENCE, new TypeRef<GetProbeReferenceResponse>(){});
+        return graphQLClient.query(request, GET_PROBE_REFERENCE, new TypeRef<GetProbeReferenceResponse>(){});
     }
 
     /**
@@ -1113,11 +1116,11 @@ public class LitmusClient implements AutoCloseable {
      *
      * @param query
      * @return Returns the YAML of the Probe
+     * @throws LitmusApiException
      */
-    public GetProbeYAMLResponse getProbeYAML(GetProbeYAMLGraphQLQuery query){
+    public GetProbeYAMLResponse getProbeYAML(GetProbeYAMLGraphQLQuery query) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(GET_PROBE_YAML, new TypeRef<GetProbeYAMLResponse>(){});
+        return graphQLClient.query(request, GET_PROBE_YAML, new TypeRef<GetProbeYAMLResponse>(){});
     }
 
     /**
@@ -1126,11 +1129,11 @@ public class LitmusClient implements AutoCloseable {
      * @param query
      * @param projectionRoot
      * @return Returns the list of Probes
+     * @throws LitmusApiException
      */
-    public List<GetProbesInExperimentRunResponse> getProbesInExperimentRun(GetProbesInExperimentRunGraphQLQuery query, GetProbesInExperimentRunProjectionRoot projectionRoot){
+    public List<GetProbesInExperimentRunResponse> getProbesInExperimentRun(GetProbesInExperimentRunGraphQLQuery query, GetProbesInExperimentRunProjectionRoot projectionRoot) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query, projectionRoot).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(GET_PROBES_IN_EXPERIMENT_RUN, new TypeRef<List<GetProbesInExperimentRunResponse>>(){});
+        return graphQLClient.query(request, GET_PROBES_IN_EXPERIMENT_RUN, new TypeRef<List<GetProbesInExperimentRunResponse>>(){});
     }
 
     /**
@@ -1139,11 +1142,11 @@ public class LitmusClient implements AutoCloseable {
      * @param query
      * @param projectionRoot
      * @return Returns the added Probe
+     * @throws LitmusApiException
      */
-    public Probe addProbe(AddProbeGraphQLQuery query, AddProbeProjectionRoot projectionRoot){
+    public Probe addProbe(AddProbeGraphQLQuery query, AddProbeProjectionRoot projectionRoot) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query, projectionRoot).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(ADD_PROBE, new TypeRef<Probe>(){});
+        return graphQLClient.query(request, ADD_PROBE, new TypeRef<Probe>(){});
     }
 
     /**
@@ -1151,11 +1154,11 @@ public class LitmusClient implements AutoCloseable {
      *
      * @param query
      * @return Returns the response of the delete probe request
+     * @throws LitmusApiException
      */
-    public DeleteProbeResponse deleteProbe(DeleteProbeGraphQLQuery query){
+    public DeleteProbeResponse deleteProbe(DeleteProbeGraphQLQuery query) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(DELETE_PROBE, new TypeRef<DeleteProbeResponse>(){});
+        return graphQLClient.query(request, DELETE_PROBE, new TypeRef<DeleteProbeResponse>(){});
     }
 
     /**
@@ -1163,11 +1166,11 @@ public class LitmusClient implements AutoCloseable {
      *
      * @param query
      * @return Returns the updated Probe
+     * @throws LitmusApiException
      */
-    public UpdateProbeResponse updateProbe(UpdateProbeGraphQLQuery query){
+    public UpdateProbeResponse updateProbe(UpdateProbeGraphQLQuery query) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(UPDATE_PROBE, new TypeRef<UpdateProbeResponse>(){});
+        return graphQLClient.query(request, UPDATE_PROBE, new TypeRef<UpdateProbeResponse>(){});
     }
 
     /**
@@ -1176,11 +1179,11 @@ public class LitmusClient implements AutoCloseable {
      * @param query
      * @param projectionRoot
      * @return Returns the list of faults
+     * @throws LitmusApiException
      */
-    public FaultDetails getChaosFault(GetChaosFaultGraphQLQuery query, GetChaosFaultProjectionRoot projectionRoot){
+    public FaultDetails getChaosFault(GetChaosFaultGraphQLQuery query, GetChaosFaultProjectionRoot projectionRoot) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query, projectionRoot).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(GET_CHAOS_FAULT, new TypeRef<FaultDetails>(){});
+        return graphQLClient.query(request, GET_CHAOS_FAULT, new TypeRef<FaultDetails>(){});
     }
 
     /**
@@ -1189,11 +1192,11 @@ public class LitmusClient implements AutoCloseable {
      * @param query
      * @param projectionRoot
      * @return Returns the list of chaos faults
+     * @throws LitmusApiException
      */
-    public List<Chart> listChaosFaults(ListChaosFaultsGraphQLQuery query, ListChaosFaultsProjectionRoot projectionRoot){
+    public List<Chart> listChaosFaults(ListChaosFaultsGraphQLQuery query, ListChaosFaultsProjectionRoot projectionRoot) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query, projectionRoot).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(LIST_CHAOS_FAULTS, new TypeRef<List<Chart>>(){});
+        return graphQLClient.query(request, LIST_CHAOS_FAULTS, new TypeRef<List<Chart>>(){});
     }
 
     /**
@@ -1202,11 +1205,11 @@ public class LitmusClient implements AutoCloseable {
      * @param query
      * @param projectionRoot
      * @return Returns the version of gql server
+     * @throws LitmusApiException
      */
-    public ServerVersionResponse getServerVersion(GetServerVersionGraphQLQuery query, GetServerVersionProjectionRoot projectionRoot){
+    public ServerVersionResponse getServerVersion(GetServerVersionGraphQLQuery query, GetServerVersionProjectionRoot projectionRoot) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query, projectionRoot).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(GET_SERVER_VERSION, new TypeRef<ServerVersionResponse>(){});
+        return graphQLClient.query(request, GET_SERVER_VERSION, new TypeRef<ServerVersionResponse>(){});
     }
 
     /**
@@ -1215,11 +1218,11 @@ public class LitmusClient implements AutoCloseable {
      * @param query
      * @param projectionRoot
      * @return Returns the latest version of infra available
+     * @throws LitmusApiException
      */
-    public InfraVersionDetails getVersionDetails(GetVersionDetailsGraphQLQuery query, GetVersionDetailsProjectionRoot projectionRoot){
+    public InfraVersionDetails getVersionDetails(GetVersionDetailsGraphQLQuery query, GetVersionDetailsProjectionRoot projectionRoot) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query, projectionRoot).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(GET_VERSION_DETAILS, new TypeRef<InfraVersionDetails>(){});
+        return graphQLClient.query(request, GET_VERSION_DETAILS, new TypeRef<InfraVersionDetails>(){});
     }
 
     /**
@@ -1228,11 +1231,11 @@ public class LitmusClient implements AutoCloseable {
      * @param query
      * @param projectionRoot
      * @return Returns the generated SSH key
+     * @throws LitmusApiException
      */
-    public SSHKey generateSSHKey(GenerateSSHKeyGraphQLQuery query, GenerateSSHKeyProjectionRoot projectionRoot){
+    public SSHKey generateSSHKey(GenerateSSHKeyGraphQLQuery query, GenerateSSHKeyProjectionRoot projectionRoot) throws LitmusApiException {
         String request = new GraphQLQueryRequest(query, projectionRoot).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(GENERATE_SSH_KEY, new TypeRef<SSHKey>(){});
+        return graphQLClient.query(request, GENERATE_SSH_KEY, new TypeRef<SSHKey>(){});
     }
 
     /**
@@ -1240,11 +1243,11 @@ public class LitmusClient implements AutoCloseable {
      *
      * @param query
      * @return Returns the manifest details
+     * @throws LitmusApiException
      */
-    public GetManifestWithInfraIDResponse getManifestWithInfraID(GetManifestWithInfraIDGraphQLQuery query){
+    public GetManifestWithInfraIDResponse getManifestWithInfraID(GetManifestWithInfraIDGraphQLQuery query) throws LitmusApiException{
         String request = new GraphQLQueryRequest(query).serialize();
-        GraphQLResponse response = graphQLClient.query(request);
-        return response.extractValueAsObject(GET_MANIFEST_WITH_INFRA_ID, new TypeRef<GetManifestWithInfraIDResponse>(){});
+        return graphQLClient.query(request, GET_MANIFEST_WITH_INFRA_ID, new TypeRef<GetManifestWithInfraIDResponse>(){});
     }
 
     // TODO: subscription is not supported in current version
@@ -1285,3 +1288,78 @@ public class LitmusClient implements AutoCloseable {
         return url.replaceAll("/$", "");
     }
 }
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+
+

--- a/src/main/java/io/litmuschaos/constants/HttpStatus.java
+++ b/src/main/java/io/litmuschaos/constants/HttpStatus.java
@@ -1,0 +1,9 @@
+package io.litmuschaos.constants;
+
+public class HttpStatus {
+    public static final int OK = 200;
+    public static final int BAD_REQUEST = 400;
+    public static final int UNAUTHORIZED = 401;
+    public static final int FORBIDDEN = 403;
+    public static final int NOT_FOUND = 404;
+}

--- a/src/main/java/io/litmuschaos/graphql/LitmusGraphQLClient.java
+++ b/src/main/java/io/litmuschaos/graphql/LitmusGraphQLClient.java
@@ -1,17 +1,18 @@
 package io.litmuschaos.graphql;
+import com.jayway.jsonpath.TypeRef;
 import com.netflix.graphql.dgs.client.GraphQLClient;
 import com.netflix.graphql.dgs.client.GraphQLResponse;
 import com.netflix.graphql.dgs.client.HttpResponse;
 import java.io.IOException;
-import java.util.Map;
-
+import io.litmuschaos.constants.HttpStatus;
+import io.litmuschaos.exception.LitmusApiException;
 import okhttp3.MediaType;
 import okhttp3.OkHttpClient;
 import okhttp3.Request;
 import okhttp3.RequestBody;
 import okhttp3.Response;
 
-import static io.litmuschaos.constants.RequestHeaders.BEARER;
+import static io.litmuschaos.constants.RequestHeaders.*;
 
 
 public class LitmusGraphQLClient {
@@ -22,26 +23,27 @@ public class LitmusGraphQLClient {
         client = GraphQLClient.createCustom(host, ((url, headers, body) -> {
             Request request = new Request.Builder()
                 .url(url)
-                .addHeader("Authorization", BEARER + " " + token)
-                .post(RequestBody.create(body, MediaType.parse("application/json"))
+                .addHeader(AUTHORIZATION, BEARER + " " + token)
+                .post(RequestBody.create(body, MediaType.parse(APPLICATION_JSON))
             ).build();
 
             try (Response response = okHttpClient.newCall(request).execute()) {
-                if(!response.isSuccessful()) {
-                    throw new IOException("Unexpected code " + response);
-                }
-                return new HttpResponse(response.code(), response.body().string());
+                return new HttpResponse(HttpStatus.OK, response.body().string());
             }catch (IOException e) {
                 throw new RuntimeException(e);
             }
         }));
     }
 
-    public GraphQLResponse query(String query, Map<String,Object> variables){
-        return client.executeQuery(query, variables);
+    public <T> T query(String query, String operationName, TypeRef<T> type) throws LitmusApiException {
+        GraphQLResponse response = client.executeQuery(query);
+        validateResponse(response);
+        return response.extractValueAsObject(operationName, type);
     }
 
-    public GraphQLResponse query(String query){
-        return client.executeQuery(query);
+    private void validateResponse(GraphQLResponse response) throws LitmusApiException {
+        if (response.hasErrors()){
+            throw new LitmusApiException(response.getErrors().get(0).getMessage());
+        }
     }
 }

--- a/src/main/java/io/litmuschaos/http/HttpResponseHandler.java
+++ b/src/main/java/io/litmuschaos/http/HttpResponseHandler.java
@@ -1,6 +1,7 @@
 package io.litmuschaos.http;
 
 import com.google.gson.*;
+import io.litmuschaos.constants.HttpStatus;
 import io.litmuschaos.constants.ResponseBodyFields;
 import io.litmuschaos.exception.LitmusApiException;
 import io.litmuschaos.exception.detailed.*;
@@ -37,13 +38,13 @@ public class HttpResponseHandler {
             }
         }
         switch (response.code()) {
-            case 400:
+            case HttpStatus.BAD_REQUEST:
                 throw new BadRequestException(errorMessage);
-            case 401:
+            case HttpStatus.UNAUTHORIZED:
                 throw new UnauthorizedException(errorMessage);
-            case 403:
+            case HttpStatus.FORBIDDEN:
                 throw new ForbiddenException(errorMessage);
-            case 404:
+            case HttpStatus.NOT_FOUND:
                 throw new NotFoundException(errorMessage);
             default:
                 throw new InternalServerErrorException(errorMessage);

--- a/src/test/java/io/litmuschaos/LitmusClientTest.java
+++ b/src/test/java/io/litmuschaos/LitmusClientTest.java
@@ -314,7 +314,7 @@ class LitmusClientTest {
      */
 
     @Test
-    void getEnvironment() {
+    void getEnvironment() throws LitmusApiException{
         GetEnvironmentGraphQLQuery query = new GetEnvironmentGraphQLQuery.Builder()
                 .projectID("567ccf04-7195-4311-a215-0803fe5e93f6")
                 .environmentID("test-environments")
@@ -338,7 +338,7 @@ class LitmusClientTest {
     }
 
     @Test
-    void listEnvironments() {
+    void listEnvironments() throws LitmusApiException{
         ListEnvironmentsGraphQLQuery query = new ListEnvironmentsGraphQLQuery.Builder()
                 .projectID("567ccf04-7195-4311-a215-0803fe5e93f6")
                 .request(new ListEnvironmentRequest.Builder()
@@ -375,7 +375,7 @@ class LitmusClientTest {
     }
 
     @Test
-    void createEnvironment() {
+    void createEnvironment() throws LitmusApiException{
         CreateEnvironmentGraphQLQuery query = new CreateEnvironmentGraphQLQuery.Builder()
                 .projectID("567ccf04-7195-4311-a215-0803fe5e93f6")
                 .request(CreateEnvironmentRequest.newBuilder()
@@ -408,7 +408,7 @@ class LitmusClientTest {
     }
 
     @Test
-    void updateEnvironment() {
+    void updateEnvironment() throws LitmusApiException{
         UpdateEnvironmentGraphQLQuery query = new UpdateEnvironmentGraphQLQuery.Builder()
                 .projectID("567ccf04-7195-4311-a215-0803fe5e93f6")
                 .request(UpdateEnvironmentRequest.newBuilder()
@@ -426,7 +426,7 @@ class LitmusClientTest {
     }
 
     @Test
-    void deleteEnvironment() {
+    void deleteEnvironment() throws LitmusApiException{
         DeleteEnvironmentGraphQLQuery query = new DeleteEnvironmentGraphQLQuery.Builder()
                 .projectID("567ccf04-7195-4311-a215-0803fe5e93f6")
                 .environmentID("test-environments")
@@ -437,7 +437,7 @@ class LitmusClientTest {
     }
 
     @Test
-    void getInfra() {
+    void getInfra() throws LitmusApiException {
         GetInfraGraphQLQuery query = new GetInfraGraphQLQuery.Builder()
                 .projectID("d6f0b5cb-0088-4732-8c2f-4193419103de")
                 .infraID("6c54cea0-16e1-4d7b-bf96-ece11c82a7e4")
@@ -455,7 +455,7 @@ class LitmusClientTest {
     }
 
     @Test
-    void listInfras() {
+    void listInfras() throws LitmusApiException {
         ListInfrasGraphQLQuery query = new ListInfrasGraphQLQuery.Builder()
                 .projectID("567ccf04-7195-4311-a215-0803fe5e93f6")
                 .request(new ListInfraRequest.Builder()
@@ -505,7 +505,7 @@ class LitmusClientTest {
     }
 
     @Test
-    void getInfraDetails(){
+    void getInfraDetails() throws LitmusApiException {
         GetInfraDetailsGraphQLQuery query = new GetInfraDetailsGraphQLQuery.Builder()
                 .projectID("567ccf04-7195-4311-a215-0803fe5e93f6")
                 .infraID("a53f0ffc-d8df-4963-8701-c1b6de179531")
@@ -542,7 +542,7 @@ class LitmusClientTest {
     }
 
     @Test
-    void getInfraStats(){
+    void getInfraStats() throws LitmusApiException {
         GetInfraStatsGraphQLQuery query = new GetInfraStatsGraphQLQuery.Builder()
                 .projectID("567ccf04-7195-4311-a215-0803fe5e93f6")
                 .build();
@@ -561,7 +561,7 @@ class LitmusClientTest {
 
     // TODO: NOT TESTED, it is used in litmus but when i call API, result not exist
     @Test
-    void getInfraManifest(){
+    void getInfraManifest() throws LitmusApiException {
         GetInfraManifestGraphQLQuery query = new GetInfraManifestGraphQLQuery.Builder()
                 .infraID("6c54cea0-16e1-4d7b-bf96-ece11c82a7e4")
                 .projectID("d6f0b5cb-0088-4732-8c2f-4193419103de")
@@ -575,7 +575,7 @@ class LitmusClientTest {
 
     // TODO: NOT TESTED
     @Test
-    void confirmInfraRegistration(){
+    void confirmInfraRegistration() throws LitmusApiException {
         ConfirmInfraRegistrationGraphQLQuery query = new ConfirmInfraRegistrationGraphQLQuery.Builder()
                 .request(InfraIdentity.newBuilder()
                         .infraID("50703e0e-18de-4cc4-80fb-0784c100bb07")
@@ -595,7 +595,7 @@ class LitmusClientTest {
     }
 
     @Test
-    void deleteInfra(){
+    void deleteInfra() throws LitmusApiException {
         DeleteInfraGraphQLQuery query = new DeleteInfraGraphQLQuery.Builder()
                 .projectID("567ccf04-7195-4311-a215-0803fe5e93f6")
                 .infraID("a53f0ffc-d8df-4963-8701-c1b6de179531")
@@ -606,7 +606,7 @@ class LitmusClientTest {
     }
 
     @Test
-    void registerInfra(){
+    void registerInfra() throws LitmusApiException {
         RegisterInfraGraphQLQuery query = new RegisterInfraGraphQLQuery.Builder()
                 .projectID("567ccf04-7195-4311-a215-0803fe5e93f6")
                 .request(RegisterInfraRequest.newBuilder()
@@ -636,7 +636,7 @@ class LitmusClientTest {
     }
 
     @Test
-    void listChaosHub(){
+    void listChaosHub() throws LitmusApiException {
         ListChaosHubGraphQLQuery query = new ListChaosHubGraphQLQuery.Builder()
                 .projectID("567ccf04-7195-4311-a215-0803fe5e93f6")
                 .request(new ListChaosHubRequest.Builder()
@@ -664,7 +664,7 @@ class LitmusClientTest {
     }
 
     @Test
-    void getChaosHub(){
+    void getChaosHub() throws LitmusApiException {
         GetChaosHubGraphQLQuery query = new GetChaosHubGraphQLQuery.Builder()
                 .projectID("567ccf04-7195-4311-a215-0803fe5e93f6")
                 .chaosHubID("218fb866-8406-4397-996a-36b75416d683")
@@ -684,7 +684,7 @@ class LitmusClientTest {
     }
 
     @Test
-    void getChaosHubStats(){
+    void getChaosHubStats() throws LitmusApiException {
         GetChaosHubStatsGraphQLQuery query = new GetChaosHubStatsGraphQLQuery.Builder()
                 .projectID("567ccf04-7195-4311-a215-0803fe5e93f6")
                 .build();
@@ -697,7 +697,7 @@ class LitmusClientTest {
     }
 
     @Test
-    void addChaosHub(){
+    void addChaosHub() throws LitmusApiException {
         AddChaosHubGraphQLQuery query = new AddChaosHubGraphQLQuery.Builder()
                 .projectID("567ccf04-7195-4311-a215-0803fe5e93f6")
                 .request(CreateChaosHubRequest.newBuilder()
@@ -725,7 +725,7 @@ class LitmusClientTest {
 
     // TODO: NOT TESTED, may not used
     @Test
-    void addRemoteChaosHub(){
+    void addRemoteChaosHub() throws LitmusApiException {
         AddRemoteChaosHubGraphQLQuery query = new AddRemoteChaosHubGraphQLQuery.Builder()
                 .projectID("567ccf04-7195-4311-a215-0803fe5e93f6")
                 .request(CreateRemoteChaosHub.newBuilder()
@@ -749,7 +749,7 @@ class LitmusClientTest {
     }
 
     @Test
-    void deleteChaosHub(){
+    void deleteChaosHub() throws LitmusApiException {
         DeleteChaosHubGraphQLQuery query = new DeleteChaosHubGraphQLQuery.Builder()
                 .projectID("567ccf04-7195-4311-a215-0803fe5e93f6")
                 .hubID("218fb866-8406-4397-996a-36b75416d683")
@@ -760,7 +760,7 @@ class LitmusClientTest {
     }
 
     @Test
-    void saveChaosHub(){
+    void saveChaosHub() throws LitmusApiException {
         SaveChaosHubGraphQLQuery query = new SaveChaosHubGraphQLQuery.Builder()
                 .projectID("50703e0e-18de-4cc4-80fb-0784c100bb07")
                 .request(CreateChaosHubRequest.newBuilder()
@@ -784,7 +784,7 @@ class LitmusClientTest {
     }
 
     @Test
-    void syncChaosHub(){
+    void syncChaosHub() throws LitmusApiException {
         SyncChaosHubGraphQLQuery query = new SyncChaosHubGraphQLQuery.Builder()
                 .projectID("567ccf04-7195-4311-a215-0803fe5e93f6")
                 .id("218fb866-8406-4397-996a-36b75416d683")
@@ -795,7 +795,7 @@ class LitmusClientTest {
     }
 
     @Test
-    void updateChaosHub(){
+    void updateChaosHub() throws LitmusApiException {
         UpdateChaosHubGraphQLQuery query = new UpdateChaosHubGraphQLQuery.Builder()
                 .projectID("567ccf04-7195-4311-a215-0803fe5e93f6")
                 .request(UpdateChaosHubRequest.newBuilder()
@@ -820,7 +820,7 @@ class LitmusClientTest {
     }
 
     @Test
-    void getExperiment(){
+    void getExperiment() throws LitmusApiException {
         GetExperimentGraphQLQuery query = new GetExperimentGraphQLQuery.Builder()
                 .projectID("d6f0b5cb-0088-4732-8c2f-4193419103de")
                 .experimentID("0eab377f-d8dc-491d-af40-dfebf110b4fe")
@@ -840,7 +840,7 @@ class LitmusClientTest {
     }
 
     @Test
-    void listExperiment(){
+    void listExperiment() throws LitmusApiException {
         ListExperimentGraphQLQuery query = new ListExperimentGraphQLQuery.Builder()
                 .projectID("d6f0b5cb-0088-4732-8c2f-4193419103de")
                 .request(new ListExperimentRequest.Builder()
@@ -879,7 +879,7 @@ class LitmusClientTest {
     }
 
     @Test
-    void getExperimentStats(){
+    void getExperimentStats() throws LitmusApiException {
         GetExperimentStatsGraphQLQuery query = new GetExperimentStatsGraphQLQuery.Builder()
                 .projectID("d6f0b5cb-0088-4732-8c2f-4193419103de")
                 .build();
@@ -893,7 +893,7 @@ class LitmusClientTest {
     }
 
     @Test
-    void getPredefinedExperiment(){
+    void getPredefinedExperiment() throws LitmusApiException {
         GetPredefinedExperimentGraphQLQuery query = new GetPredefinedExperimentGraphQLQuery.Builder()
                 .projectID("d6f0b5cb-0088-4732-8c2f-4193419103de")
                 .experimentName(List.of("Node CPU Hog"))
@@ -910,7 +910,7 @@ class LitmusClientTest {
     }
 
     @Test
-    void listPredefinedExperiments(){
+    void listPredefinedExperiments() throws LitmusApiException {
         ListPredefinedExperimentsGraphQLQuery query = new ListPredefinedExperimentsGraphQLQuery.Builder()
                 .projectID("567ccf04-7195-4311-a215-0803fe5e93f6")
                 .hubID("6f39cea9-6264-4951-83a8-29976b614289")
@@ -926,7 +926,7 @@ class LitmusClientTest {
     }
 
     @Test
-    void runChaosExperiment(){
+    void runChaosExperiment() throws LitmusApiException {
         RunChaosExperimentGraphQLQuery query = new RunChaosExperimentGraphQLQuery.Builder()
                 .projectID("567ccf04-7195-4311-a215-0803fe5e93f6")
                 .experimentID("1af067d5-fec7-4117-92df-036f5a571372")
@@ -940,7 +940,7 @@ class LitmusClientTest {
     }
 
     @Test
-    void saveChaosExperiment(){
+    void saveChaosExperiment() throws LitmusApiException {
         SaveChaosExperimentGraphQLQuery query = new SaveChaosExperimentGraphQLQuery.Builder()
                 .projectID("d6f0b5cb-0088-4732-8c2f-4193419103de")
                 .request(SaveChaosExperimentRequest.newBuilder()
@@ -959,7 +959,7 @@ class LitmusClientTest {
     }
 
     @Test
-    void updateChaosExperiment(){
+    void updateChaosExperiment() throws LitmusApiException {
         UpdateChaosExperimentGraphQLQuery query = new UpdateChaosExperimentGraphQLQuery.Builder()
                 .projectID("50703e0e-18de-4cc4-80fb-0784c100bb07")
                 .request(ChaosExperimentRequest.newBuilder()
@@ -982,7 +982,7 @@ class LitmusClientTest {
 
     // TODO: NOT TESTED, may be not used
     @Test
-    void createChaosExperiment(){
+    void createChaosExperiment() throws LitmusApiException {
         CreateChaosExperimentGraphQLQuery query = new CreateChaosExperimentGraphQLQuery.Builder()
                 .projectID("d6f0b5cb-0088-4732-8c2f-4193419103de")
                 .request(
@@ -1010,7 +1010,7 @@ class LitmusClientTest {
     }
 
     @Test
-    void deleteChaosExperiment(){
+    void deleteChaosExperiment() throws LitmusApiException {
         DeleteChaosExperimentGraphQLQuery query = new DeleteChaosExperimentGraphQLQuery.Builder()
                 .projectID("50703e0e-18de-4cc4-80fb-0784c100bb07")
                 .experimentID("50703e0e-18de-4cc4-80fb-0784c100bb07")
@@ -1022,7 +1022,7 @@ class LitmusClientTest {
     }
 
     @Test
-    void updateCronExperimentState(){
+    void updateCronExperimentState() throws LitmusApiException {
         UpdateCronExperimentStateGraphQLQuery query = new UpdateCronExperimentStateGraphQLQuery.Builder()
                 .projectID("50703e0e-18de-4cc4-80fb-0784c100bb07")
                 .experimentID("50703e0e-18de-4cc4-80fb-0784c100bb07")
@@ -1035,7 +1035,7 @@ class LitmusClientTest {
 
     // Chaos Experiment Run
     @Test
-    void getExperimentRun(){
+    void getExperimentRun() throws LitmusApiException {
         GetExperimentRunGraphQLQuery query = new GetExperimentRunGraphQLQuery.Builder()
                 .projectID("567ccf04-7195-4311-a215-0803fe5e93f6")
                 .notifyID("7502028c-1103-4c54-8ac3-e5b5ec9b49f5")
@@ -1059,7 +1059,7 @@ class LitmusClientTest {
     }
 
     @Test
-    void getExperimentRunStats(){
+    void getExperimentRunStats() throws LitmusApiException {
         GetExperimentRunStatsGraphQLQuery query = new GetExperimentRunStatsGraphQLQuery.Builder()
                 .projectID("567ccf04-7195-4311-a215-0803fe5e93f6")
                 .build();
@@ -1077,7 +1077,7 @@ class LitmusClientTest {
     }
 
     @Test
-    void listExperimentRun(){
+    void listExperimentRun() throws LitmusApiException {
         ListExperimentRunGraphQLQuery query = new ListExperimentRunGraphQLQuery.Builder()
                 .projectID("567ccf04-7195-4311-a215-0803fe5e93f6")
                 .request(new ListExperimentRunRequest.Builder()
@@ -1110,7 +1110,7 @@ class LitmusClientTest {
 
     // TODO: NOT TESTED, may be not used
     @Test
-    void chaosExperimentRun(){
+    void chaosExperimentRun() throws LitmusApiException {
         ChaosExperimentRunGraphQLQuery query = new ChaosExperimentRunGraphQLQuery.Builder()
                 .request(ExperimentRunRequest.newBuilder()
                         .experimentID("1af067d5-fec7-4117-92df-036f5a571372")
@@ -1125,7 +1125,7 @@ class LitmusClientTest {
     }
 
     @Test
-    void stopExperimentRuns(){
+    void stopExperimentRuns() throws LitmusApiException {
         StopExperimentRunsGraphQLQuery query = new StopExperimentRunsGraphQLQuery.Builder()
                 .projectID("567ccf04-7195-4311-a215-0803fe5e93f6")
                 .experimentID("1af067d5-fec7-4117-92df-036f5a571372")
@@ -1137,7 +1137,7 @@ class LitmusClientTest {
 
     // GitOps
     @Test
-    void getGitOpsDetails(){
+    void getGitOpsDetails() throws LitmusApiException {
         GetGitOpsDetailsGraphQLQuery query = new GetGitOpsDetailsGraphQLQuery.Builder()
                 .projectID("d6f0b5cb-0088-4732-8c2f-4193419103de")
                 .build();
@@ -1152,7 +1152,7 @@ class LitmusClientTest {
     }
 
     @Test
-    void disableGitOps(){
+    void disableGitOps() throws LitmusApiException {
         DisableGitOpsGraphQLQuery query = new DisableGitOpsGraphQLQuery.Builder()
                 .projectID("d6f0b5cb-0088-4732-8c2f-4193419103de")
                 .build();
@@ -1163,7 +1163,7 @@ class LitmusClientTest {
 
     // TODO: NOT TESTED
     @Test
-    void enableGitOps(){
+    void enableGitOps() throws LitmusApiException {
         EnableGitOpsGraphQLQuery query = new EnableGitOpsGraphQLQuery.Builder()
                 .projectID("567ccf04-7195-4311-a215-0803fe5e93f6")
                 .configurations(GitConfig.newBuilder()
@@ -1181,7 +1181,7 @@ class LitmusClientTest {
 
     // TODO: NOT TESTED
     @Test
-    void gitopsNotifier(){
+    void gitopsNotifier() throws LitmusApiException {
         GitopsNotifierGraphQLQuery query = new GitopsNotifierGraphQLQuery.Builder()
                 .experimentID("50703e0e-18de-4cc4-80fb-0784c100bb07")
                 .clusterInfo(InfraIdentity.newBuilder()
@@ -1197,7 +1197,7 @@ class LitmusClientTest {
 
     // TODO: NOT TESTED
     @Test
-    void updateGitOps(){
+    void updateGitOps() throws LitmusApiException {
         UpdateGitOpsGraphQLQuery query = new UpdateGitOpsGraphQLQuery.Builder()
                 .projectID("d6f0b5cb-0088-4732-8c2f-4193419103de")
                 .configurations(GitConfig.newBuilder()
@@ -1215,7 +1215,7 @@ class LitmusClientTest {
 
     // Image Registry
     @Test
-    void getImageRegistry(){
+    void getImageRegistry() throws LitmusApiException {
         GetImageRegistryGraphQLQuery query = new GetImageRegistryGraphQLQuery.Builder()
                 .projectID("d6f0b5cb-0088-4732-8c2f-4193419103de")
                 .build();
@@ -1230,7 +1230,7 @@ class LitmusClientTest {
     }
 
     @Test
-    void listImageRegistry(){
+    void listImageRegistry() throws LitmusApiException {
         ListImageRegistryGraphQLQuery query = new ListImageRegistryGraphQLQuery.Builder()
                 .projectID("d6f0b5cb-0088-4732-8c2f-4193419103de")
                 .build();
@@ -1245,7 +1245,7 @@ class LitmusClientTest {
 
     // TODO: NOT TESTED
     @Test
-    void createImageRegistry(){
+    void createImageRegistry() throws LitmusApiException {
         CreateImageRegistryGraphQLQuery query = new CreateImageRegistryGraphQLQuery.Builder()
                 .projectID("d6f0b5cb-0088-4732-8c2f-4193419103de")
                 .imageRegistryInfo(ImageRegistryInput.newBuilder()
@@ -1267,7 +1267,7 @@ class LitmusClientTest {
 
     // TODO: NOT TESTED
     @Test
-    void deleteImageRegistry(){
+    void deleteImageRegistry() throws LitmusApiException {
         DeleteImageRegistryGraphQLQuery query = new DeleteImageRegistryGraphQLQuery.Builder()
                 .projectID("d6f0b5cb-0088-4732-8c2f-4193419103de")
                 .imageRegistryID("c4f670bd-8b23-4ef0-a21f-f3a098b5b878")
@@ -1279,7 +1279,7 @@ class LitmusClientTest {
 
     // TODO: NOT TESTED
     @Test
-    void updateImageRegistry(){
+    void updateImageRegistry() throws LitmusApiException {
         UpdateImageRegistryGraphQLQuery query = new UpdateImageRegistryGraphQLQuery.Builder()
                 .projectID("d6f0b5cb-0088-4732-8c2f-4193419103de")
                 .imageRegistryID("c4f670bd-8b23-4ef0-a21f-f3a098b5b878")
@@ -1302,7 +1302,7 @@ class LitmusClientTest {
 
     // Probe
     @Test
-    void listProbes(){
+    void listProbes() throws LitmusApiException {
         ListProbesGraphQLQuery query = new ListProbesGraphQLQuery.Builder()
                 .projectID("567ccf04-7195-4311-a215-0803fe5e93f6")
                 .infrastructureType(InfrastructureType.Kubernetes) // type is Kubernetes
@@ -1326,7 +1326,7 @@ class LitmusClientTest {
     }
 
     @Test
-    void getProbe(){
+    void getProbe() throws LitmusApiException {
         GetProbeGraphQLQuery query = new GetProbeGraphQLQuery.Builder()
                 .projectID("567ccf04-7195-4311-a215-0803fe5e93f6")
                 .probeName("test-probe")
@@ -1345,7 +1345,7 @@ class LitmusClientTest {
     }
 
     @Test
-    void validateUniqueProbe(){
+    void validateUniqueProbe() throws LitmusApiException {
         ValidateUniqueProbeGraphQLQuery query = new ValidateUniqueProbeGraphQLQuery.Builder()
                 .projectID("567ccf04-7195-4311-a215-0803fe5e93f6")
                 .probeName("test-probe")
@@ -1356,7 +1356,7 @@ class LitmusClientTest {
     }
 
     @Test
-    void getProbeReference(){ // we need create long type to graphql for updatedAt timestamp field
+    void getProbeReference() throws LitmusApiException { // we need create long type to graphql for updatedAt timestamp field
         GetProbeReferenceGraphQLQuery query = new GetProbeReferenceGraphQLQuery.Builder()
                 .projectID("567ccf04-7195-4311-a215-0803fe5e93f6")
                 .probeName("test-probe")
@@ -1377,7 +1377,7 @@ class LitmusClientTest {
     }
 
     @Test
-    void getProbeYAML(){
+    void getProbeYAML() throws LitmusApiException {
         GetProbeYAMLGraphQLQuery query = new GetProbeYAMLGraphQLQuery.Builder()
                 .projectID("567ccf04-7195-4311-a215-0803fe5e93f6")
                 .request(GetProbeYAMLRequest.newBuilder()
@@ -1391,7 +1391,7 @@ class LitmusClientTest {
     }
 
     @Test
-    void getProbesInExperimentRun(){
+    void getProbesInExperimentRun() throws LitmusApiException {
         GetProbesInExperimentRunGraphQLQuery query = new GetProbesInExperimentRunGraphQLQuery.Builder()
                 .projectID("d6f0b5cb-0088-4732-8c2f-4193419103de")
                 .experimentRunID("cd368e9b-1ac1-4606-8f62-65af6a5d838b")
@@ -1406,7 +1406,7 @@ class LitmusClientTest {
     }
 
     @Test
-    void addProbe(){
+    void addProbe() throws LitmusApiException {
         AddProbeGraphQLQuery query = new AddProbeGraphQLQuery.Builder()
                 .projectID("567ccf04-7195-4311-a215-0803fe5e93f6")
                 .request(ProbeRequest.newBuilder()
@@ -1440,7 +1440,7 @@ class LitmusClientTest {
     }
 
     @Test
-    void deleteProbe(){
+    void deleteProbe() throws LitmusApiException {
         DeleteProbeGraphQLQuery query = new DeleteProbeGraphQLQuery.Builder()
                 .projectID("567ccf04-7195-4311-a215-0803fe5e93f6")
                 .probeName("test name")
@@ -1451,7 +1451,7 @@ class LitmusClientTest {
     }
 
     @Test
-    void updateProbe(){
+    void updateProbe() throws LitmusApiException {
         UpdateProbeGraphQLQuery query = new UpdateProbeGraphQLQuery.Builder()
                 .projectID("567ccf04-7195-4311-a215-0803fe5e93f6")
                 .request(ProbeRequest.newBuilder()
@@ -1481,7 +1481,7 @@ class LitmusClientTest {
 
     // chaos fault
     @Test
-    void getChaosFault(){
+    void getChaosFault() throws LitmusApiException {
         GetChaosFaultGraphQLQuery query = new GetChaosFaultGraphQLQuery.Builder()
                 .projectID("567ccf04-7195-4311-a215-0803fe5e93f6")
                 .request(ExperimentRequest.newBuilder()
@@ -1501,7 +1501,7 @@ class LitmusClientTest {
     }
 
     @Test
-    void listChaosFaults(){
+    void listChaosFaults() throws LitmusApiException {
         ListChaosFaultsGraphQLQuery query = new ListChaosFaultsGraphQLQuery.Builder()
                 .hubID("6f39cea9-6264-4951-83a8-29976b614289")
                 .projectID("567ccf04-7195-4311-a215-0803fe5e93f6")
@@ -1519,7 +1519,7 @@ class LitmusClientTest {
 
     // others
     @Test
-    void getServerVersion(){
+    void getServerVersion() throws LitmusApiException {
         GetServerVersionGraphQLQuery query = new GetServerVersionGraphQLQuery.Builder()
                 .build();
 
@@ -1532,7 +1532,7 @@ class LitmusClientTest {
     }
 
     @Test
-    void getVersionDetails(){
+    void getVersionDetails() throws LitmusApiException {
         GetVersionDetailsGraphQLQuery query = new GetVersionDetailsGraphQLQuery.Builder()
                 .projectID("567ccf04-7195-4311-a215-0803fe5e93f6")
                 .build();
@@ -1546,7 +1546,7 @@ class LitmusClientTest {
     }
 
     @Test
-    void generateSSHKey(){
+    void generateSSHKey() throws LitmusApiException {
         GenerateSSHKeyGraphQLQuery query = new GenerateSSHKeyGraphQLQuery.Builder()
                 .build();
 
@@ -1560,7 +1560,7 @@ class LitmusClientTest {
 
     // TODO: NOT TESTED
     @Test
-    void getManifestWithInfraID(){
+    void getManifestWithInfraID() throws LitmusApiException {
         GetManifestWithInfraIDGraphQLQuery query = new GetManifestWithInfraIDGraphQLQuery.Builder()
                 .projectID("567ccf04-7195-4311-a215-0803fe5e93f6")
                 .infraID("a53f0ffc-d8df-4963-8701-c1b6de179531")


### PR DESCRIPTION
- There are two types of exceptions related to GraphQL: one that sends a 200 OK response and another that sends an error status code. Both include error details in the errors field of the response. For Java SDK clients, understanding what issue occurred is more important than the status code, so we standardized the HTTP status as 200 OK. If there is at least one error in the errors array, a LitmusApiException is returned.

- validating and converting the response to the desired type is the responsibility of graphQLClient. Therefore, I moved the logic from litmusClient to graphQLClient.

